### PR TITLE
Update LoadActionGUI.js

### DIFF
--- a/gui/LoadActionGUI.js
+++ b/gui/LoadActionGUI.js
@@ -128,6 +128,7 @@ function isInActionGui() {
 	const containerName = Player.getContainer().getName();
 	if (Client.currentGui.getClassName() === "GuiEditSign") return
 	if (Player.getContainer().getClassName() !== 'ContainerChest') return false;
+	if (containerName === 'Edit Menu' || containerName === "Edit Elements") return false;
 	if (containerName.match(/Edit |Actions: /)) return true;
 	return false;
 }


### PR DESCRIPTION
Fixed the Load Action GUI showing up on menus that don't support it.

This might be fixed in the upcoming update, but figured I would mention it. Made this change in the version I have and it worked fine.